### PR TITLE
chore: added information needed for publishing to marketplace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ package-lock.json
 .github/
 .vscode-test/
 out/test/
+PAT

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Curtis Mechling
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "description": "A Visual Studio Code extension to streamline development of Wireshark Lua dissector scripts.",
   "license": "MIT",
   "author": "Curtis Mechling <cmechlin@gmail.com>",
+  "publisher": "CurtisMechling",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cmechlin/wireshark-lua-toolkit.git"
+  },
   "engines": {
     "vscode": "^1.101.0"
   },


### PR DESCRIPTION
Needed a few small changes to publish to the vscode marketplace

## Summary by Sourcery

Prepare the extension for publishing to the VS Code Marketplace by adding required metadata and a license file.

Chores:
- Add `publisher` and `repository` fields to package.json for Marketplace publishing
- Add `LICENSE.md` containing the MIT license